### PR TITLE
init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+#### joe made this: http://goel.io/joe
+#### go ####
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+/.idea
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+  - 1.11

--- a/condition.go
+++ b/condition.go
@@ -1,0 +1,150 @@
+package elasticqueue
+
+import (
+	"math"
+	"time"
+)
+
+// Condition is passed to the Queue to determine when it should be written out.
+type Condition interface {
+	// Inserted is called synchronously whenever a document is inserted into
+	// the ElasticSearch queue. It should return true if the queue should be
+	// immediately flushed to ElasticSearch.
+	Inserted(document []byte, length int) (writeImmediately bool)
+
+	// Write is called by the Queue once when first created. It returns a
+	// channel which should emit whenever. This may return nil if the
+	// condition does not care to do asynchronous writes.
+	Write() (doWrite <-chan struct{}, cancel func())
+
+	// Flushed is called whenever the queue is written out.
+	Flushed()
+}
+
+var maxDuration = time.Duration(math.MaxInt64)
+
+// writeAfterTimer is a helper function that returns the data wanted by
+// Condition.Write after the timer fires.
+func writeAfterTimer(timer *time.Timer) (doWrite <-chan struct{}, cancel func()) {
+	ch := make(chan struct{})
+	closer := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-timer.C:
+				select {
+				case ch <- struct{}{}:
+				case <-closer:
+					return
+				}
+			case <-closer:
+				return
+			}
+		}
+	}()
+
+	return ch, func() { close(ch); timer.Stop() }
+}
+
+// WriteAfterIdle returns a write condition which'll cause the queue to be
+// written out to ElasticSearch after no documents are written for
+// a period of time.
+func WriteAfterIdle(interval time.Duration) Condition {
+	return &afterIdleCondition{
+		interval: interval,
+		timer:    time.NewTimer(maxDuration),
+	}
+}
+
+var _ Condition = &afterIdleCondition{}
+
+type afterIdleCondition struct {
+	timer    *time.Timer
+	interval time.Duration
+}
+
+// Inserted implements Condition.Inserted
+func (a *afterIdleCondition) Inserted(_ []byte, _ int) (writeImmediately bool) {
+	a.timer.Reset(a.interval)
+	return false
+}
+
+// Write implements Condition.Write
+func (a *afterIdleCondition) Write() (doWrite <-chan struct{}, cancel func()) {
+	return writeAfterTimer(a.timer)
+}
+
+// Flushed implements Condition.Flushed
+func (a *afterIdleCondition) Flushed() { a.timer.Reset(maxDuration) }
+
+// WriteAfterInterval returns a write condition which'll cause the queue to be
+// written out after a constant amount of time after the first write.
+func WriteAfterInterval(interval time.Duration) Condition {
+	return &afterIntervalCondition{interval: interval}
+}
+
+var _ Condition = &afterIntervalCondition{}
+
+type afterIntervalCondition struct {
+	timer    *time.Timer
+	interval time.Duration
+}
+
+// Inserted implements Condition.Inserted
+func (a *afterIntervalCondition) Inserted(_ []byte, length int) (writeImmediately bool) {
+	if length == 1 {
+		a.timer = time.NewTimer(a.interval)
+	}
+
+	return false
+}
+
+// Write implements Condition.Write
+func (a *afterIntervalCondition) Write() (doWrite <-chan struct{}, cancel func()) {
+	return writeAfterTimer(a.timer)
+}
+
+// Flushed implements Condition.Flushed
+func (a *afterIntervalCondition) Flushed() { a.timer.Reset(maxDuration) }
+
+// WriteAfterLength returns a write condition which'll cause the queue to be
+// written out after it reaches a predefined length.
+func WriteAfterLength(length int) Condition { return afterLengthCondition{length} }
+
+var _ Condition = afterLengthCondition{}
+
+type afterLengthCondition struct{ length int }
+
+// Inserted implements Condition.Inserted
+func (a afterLengthCondition) Inserted(_ []byte, length int) (writeImmediately bool) {
+	return length == a.length
+}
+
+// Write implements Condition.Write
+func (a afterLengthCondition) Write() (doWrite <-chan struct{}, cancel func()) { return }
+
+// Flushed implements Condition.Flushed
+func (a afterLengthCondition) Flushed() {}
+
+// WriterAfterByteSize returns a write condition which'll cause the queue to be
+// written out after it's more than "maxBytes" bytes long.
+func WriterAfterByteSize(maxBytes int) Condition { return &afterByteSize{maxSize: maxBytes} }
+
+var _ Condition = &afterByteSize{}
+
+type afterByteSize struct {
+	maxSize     int
+	currentSize int
+}
+
+// Inserted implements Condition.Inserted
+func (a *afterByteSize) Inserted(document []byte, _ int) (writeImmediately bool) {
+	a.currentSize += len(document)
+	return a.currentSize >= a.maxSize
+}
+
+// Write implements Condition.Write
+func (a *afterByteSize) Write() (doWrite <-chan struct{}, cancel func()) { return }
+
+// Flushed implements Condition.Flushed
+func (a *afterByteSize) Flushed() { a.currentSize = 0 }

--- a/condition_test.go
+++ b/condition_test.go
@@ -1,0 +1,137 @@
+package elasticqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mixer/clock"
+	"github.com/stretchr/testify/assert"
+)
+
+type conditionTest struct {
+	Condition
+
+	mu     sync.Mutex
+	writes int
+	closer func()
+}
+
+func NewConditionTest(c Condition) *conditionTest {
+	ch, cancel := c.Write()
+	test := &conditionTest{Condition: c, closer: cancel}
+
+	go func() {
+		for range ch {
+			test.mu.Lock()
+			test.writes++
+			test.mu.Unlock()
+		}
+	}()
+
+	return test
+}
+
+func (c *conditionTest) Writes() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+func (c *conditionTest) WaitForWrites(i int) int {
+	deadline := time.Now().Add(time.Millisecond * 100)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		if c.writes < i {
+			c.mu.Unlock()
+			time.Sleep(time.Millisecond * 2)
+			continue
+		}
+
+		writes := c.writes
+		c.mu.Unlock()
+		return writes
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writes
+}
+
+func (c *conditionTest) Stop() { c.closer() }
+
+func TestWriteAfterIdle(t *testing.T) {
+	clock := clock.NewMockClock()
+	c := WriteAfterIdle(time.Millisecond * 50)
+	c.(*afterIdleCondition).timer = clock.NewTimer(maxDuration)
+
+	test := NewConditionTest(c)
+	defer test.Stop()
+
+	t.Run("ShouldNotWriteInitially", func(t *testing.T) {
+		clock.AddTime(time.Millisecond * 50)
+		assert.Equal(t, 0, test.WaitForWrites(1))
+	})
+
+	t.Run("ShouldWriteDataWhenIdle", func(t *testing.T) {
+		c.Inserted(nil, 1)
+		clock.AddTime(time.Millisecond * 50)
+		assert.Equal(t, 1, test.WaitForWrites(1))
+	})
+
+	t.Run("ShouldNotWriteWithNoData", func(t *testing.T) {
+		clock.AddTime(time.Millisecond * 50)
+		assert.Equal(t, 1, test.WaitForWrites(2))
+	})
+
+	t.Run("ShouldNotWriteAfterMoreEvents", func(t *testing.T) {
+		c.Inserted(nil, 1)
+		clock.AddTime(time.Millisecond * 20)
+		c.Inserted(nil, 2)
+		clock.AddTime(time.Millisecond * 40)
+		assert.Equal(t, 1, test.WaitForWrites(2))
+	})
+}
+
+func TestWriteAfterInterval(t *testing.T) {
+	clock := clock.NewMockClock()
+	c := WriteAfterInterval(time.Millisecond * 50)
+	c.(*afterIntervalCondition).timer = clock.NewTimer(maxDuration)
+
+	test := NewConditionTest(c)
+	defer test.Stop()
+
+	t.Run("ShouldNotWriteInitially", func(t *testing.T) {
+		clock.AddTime(time.Millisecond * 50)
+		assert.Equal(t, 0, test.WaitForWrites(1)) // should not write anything initially
+	})
+
+	t.Run("ShouldWriteAfterGettingEvents", func(t *testing.T) {
+		c.Inserted(nil, 1)
+		clock.AddTime(time.Millisecond * 20)
+		c.Inserted(nil, 2)
+		clock.AddTime(time.Millisecond * 40)
+		assert.Equal(t, 1, test.WaitForWrites(1))
+	})
+
+	t.Run("ShouldNotWriteWithNoData", func(t *testing.T) {
+		clock.AddTime(time.Millisecond * 50)
+		assert.Equal(t, 1, test.WaitForWrites(2))
+	})
+}
+
+func TestWriteAfterLength(t *testing.T) {
+	c := WriteAfterLength(2)
+	assert.False(t, c.Inserted(nil, 1))
+	assert.True(t, c.Inserted(nil, 2))
+}
+
+func TEstWriteAfterSize(t *testing.T) {
+	c := WriterAfterByteSize(3)
+	assert.False(t, c.Inserted([]byte{1}, 1))
+	assert.False(t, c.Inserted([]byte{1}, 1))
+	assert.True(t, c.Inserted([]byte{1}, 1))
+	c.Flushed()
+	assert.False(t, c.Inserted([]byte{1, 2}, 1))
+	assert.True(t, c.Inserted([]byte{1}, 1))
+}

--- a/elasticqueue.go
+++ b/elasticqueue.go
@@ -1,0 +1,178 @@
+package elasticqueue
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/olivere/elastic"
+)
+
+func defaultErrorHandler(err error) {
+	log.Printf("mixer/elasticqueue: error writing to elasticsearch: %s. "+
+		"(note: pass WithErrorHandler() to override default logging)", err)
+}
+
+// NewQueue creates a new ElasticSearch queue around the provided client.
+// Note that you are required to provide at least on Condition using
+// WithCondition.
+func NewQueue(client *elastic.Client, options ...Option) *Queue {
+	queue := &Queue{
+		errorHandler: defaultErrorHandler,
+		closer:       make(chan struct{}),
+	}
+
+	for _, option := range options {
+		option(queue)
+	}
+
+	if queue.requester == nil {
+		queue.requester = &ClientRequester{Client: client, Timeout: queue.timeout}
+	}
+
+	if len(queue.conditions) == 0 {
+		panic("mixer/elasticqueue: write conditions were passed, the client will buffer " +
+			"infinitely! Use WithCondition() to pass one or more options to NewQueue()")
+	}
+
+	go queue.listenToConditions()
+
+	return queue
+}
+
+// Queue is the implementation of the ElasticSearch queue.
+type Queue struct {
+	requester   Requester
+	conditions  []Condition
+	writeWaiter sync.WaitGroup
+	closer      chan struct{}
+
+	timeout      time.Duration
+	backoff      elastic.Backoff
+	errorHandler func(err error)
+
+	queueMu sync.Mutex
+	queue   []elastic.BulkableRequest
+}
+
+// Store writes the document, or queues it for writing later. This is thread-safe.
+func (q *Queue) Store(index, kind string, doc interface{}) (err error) {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("mixer/elasticqueue: error creating queue item UUID: %s", err)
+	}
+
+	return q.StoreWithId(index, kind, uuid.String(), doc)
+}
+
+// Store writes the document, or queues it for writing later. This is thread-safe.
+func (q *Queue) StoreWithId(index, kind, id string, doc interface{}) (err error) {
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("mixer/elasticqueue: error JSON encoding item queue of type %T: %s", doc, err)
+	}
+
+	q.queueMu.Lock()
+	defer q.queueMu.Unlock()
+
+	q.queue = append(q.queue, elastic.NewBulkIndexRequest().
+		Index(index).
+		Type(kind).
+		Id(id). // assign an ID so if we retry bulk ops, we don't double-write
+		Doc(json.RawMessage(encoded)))
+
+	writeNow := false
+	for _, condition := range q.conditions {
+		if condition.Inserted(encoded, len(q.queue)) {
+			writeNow = true
+		}
+	}
+
+	if writeNow {
+		q.runBackgroundWrite()
+	}
+
+	return nil
+}
+
+// Close tears down resources and writes any pending operations.
+func (q *Queue) Close() {
+	q.closer <- struct{}{}
+	<-q.closer // wait for the close to be confirmed
+	q.writeWaiter.Wait()
+
+	if len(q.queue) > 0 {
+		q.writeImmediately(q.queue)
+		q.queue = nil
+	}
+}
+
+func (q *Queue) listenToConditions() {
+	channels := []<-chan struct{}{q.closer}
+	closers := []func(){func() { close(q.closer) }}
+
+	for _, condition := range q.conditions {
+		channel, closer := condition.Write()
+		if channel == nil {
+			continue
+		}
+
+		channels = append(channels, channel)
+		closers = append(closers, closer)
+	}
+
+	cases := make([]reflect.SelectCase, 0, len(channels))
+	for _, ch := range channels {
+		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)})
+	}
+
+	for {
+		chosen, _, _ := reflect.Select(cases)
+		if chosen == 0 { // closer
+			break
+		}
+
+		q.queueMu.Lock()
+		q.runBackgroundWrite()
+		q.queueMu.Unlock()
+	}
+
+	for _, closer := range closers {
+		closer()
+	}
+}
+
+func (q *Queue) writeImmediately(queue []elastic.BulkableRequest) {
+	err := elastic.Retry(
+		func() error { return q.requester.Send(queue) },
+		q.backoff,
+	)
+
+	if err != nil {
+		q.errorHandler(err)
+	}
+}
+
+func (q *Queue) runBackgroundWrite() {
+	queue := q.queue
+	q.queue = nil
+
+	if len(queue) == 0 {
+		return
+	}
+
+	for _, condition := range q.conditions {
+		condition.Flushed()
+	}
+
+	q.writeWaiter.Add(1)
+
+	go func() {
+		q.writeImmediately(queue)
+		q.writeWaiter.Done()
+	}()
+}

--- a/elasticqueue_test.go
+++ b/elasticqueue_test.go
@@ -1,0 +1,101 @@
+package elasticqueue
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/olivere/elastic"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ElasticQueueSuite struct {
+	suite.Suite
+	r     *mockRequester
+	c     *mockCondition
+	queue *Queue
+}
+
+var (
+	mockDocument1 = json.RawMessage(`"hello world!"`)
+)
+
+type mockRequester struct {
+	mu    sync.Mutex
+	err   error
+	data  []elastic.BulkableRequest
+	calls int
+}
+
+func (m *mockRequester) WaitForData(length int) []elastic.BulkableRequest {
+	deadline := time.Now().Add(time.Millisecond * 100)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		data := m.data
+		if len(data) < length {
+			m.mu.Unlock()
+			time.Sleep(time.Millisecond * 2)
+			continue
+		}
+
+		output := make([]elastic.BulkableRequest, len(data))
+		copy(output, data)
+		m.mu.Unlock()
+		return data
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data
+}
+
+func (m *mockRequester) Send(data []elastic.BulkableRequest) error {
+	m.mu.Lock()
+	m.data = append(m.data, data...)
+	m.calls++
+	m.mu.Unlock()
+	return m.err
+}
+
+var _ Requester = &mockRequester{}
+
+type mockCondition struct {
+	mock.Mock
+	writeChannel chan struct{}
+}
+
+func (m *mockCondition) Inserted(document []byte, length int) bool {
+	return m.Called([]byte(document), length).Bool(0)
+}
+
+func (m *mockCondition) Write() (doWrite <-chan struct{}, cancel func()) {
+	return m.writeChannel, func() {}
+}
+
+func (m *mockCondition) Flushed() { m.Called() }
+
+func TestElasticQueueSuite(t *testing.T) {
+	suite.Run(t, new(ElasticQueueSuite))
+}
+
+func (e *ElasticQueueSuite) SetupTest() {
+	e.r = &mockRequester{}
+	e.c = &mockCondition{}
+}
+
+func (e *ElasticQueueSuite) TearDownTest() {
+	e.c.AssertExpectations(e.T())
+}
+
+func (e *ElasticQueueSuite) TestRunsWriteOnInsertedCheck() {
+	q := NewQueue(nil, WithRequester(e.r), WithCondition(e.c))
+	e.c.On("Inserted", mockDocument1, 1).Return(true)
+	e.Nil(q.Store("foo", "bar", mockDocument1))
+	e.Len(e.r.WaitForData(1), 1)
+	e.Equal(1, e.r.calls)
+	e.queue.Close()
+
+	e.Equal(1, e.r.calls)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,19 @@
+hash: b7101ee531de145f685ea6042f6c4162eadab5e35b2a7261bff274b20891c593
+updated: 2018-10-18T09:59:31.244901204-07:00
+imports:
+- name: github.com/google/uuid
+  version: d460ce9f8df2e77fb1ba55ca87fafed96c607494
+- name: github.com/mailru/easyjson
+  version: 60711f1a8329503b04e1c88535f419d0bb440bff
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/olivere/elastic
+  version: 425e5369a8f054f4f447f7c8ee1bf605f48425ab
+  subpackages:
+  - config
+  - uritemplates
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b7101ee531de145f685ea6042f6c4162eadab5e35b2a7261bff274b20891c593
-updated: 2018-10-18T09:59:31.244901204-07:00
+hash: 2dff66d48825f3d467c980949d385c7a541e75609257c7918b77381335c72000
+updated: 2018-10-18T13:20:33.995434536-07:00
 imports:
 - name: github.com/google/uuid
   version: d460ce9f8df2e77fb1ba55ca87fafed96c607494
@@ -9,6 +9,8 @@ imports:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/mixer/clock
+  version: 2e1c7bb73d119fe867a465e77859e3da5838dc94
 - name: github.com/olivere/elastic
   version: 425e5369a8f054f4f447f7c8ee1bf605f48425ab
   subpackages:
@@ -16,4 +18,21 @@ imports:
   - uritemplates
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
-testImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/objx
+  version: ef50b0de28773081167c97fc27cf29a0bf8b8c71
+- name: github.com/stretchr/testify
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
+  subpackages:
+  - assert
+  - mock
+  - require
+  - suite

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,5 +4,3 @@ import:
   version: ^6.2.11
 - package: github.com/google/uuid
   version: ^1.0.0
-- package: github.com/pkg/errors
-  version: ^0.8.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,8 @@
+package: github.com/mixer/elasticqueue
+import:
+- package: github.com/olivere/elastic
+  version: ^6.2.11
+- package: github.com/google/uuid
+  version: ^1.0.0
+- package: github.com/pkg/errors
+  version: ^0.8.0

--- a/option.go
+++ b/option.go
@@ -1,0 +1,48 @@
+package elasticqueue
+
+import (
+	"time"
+
+	"github.com/olivere/elastic"
+)
+
+// Option is passed to NewQueue to configure it.
+type Option func(q *Queue)
+
+// WithTimeout sets the timeout for ElasticSearch write operations.
+func WithTimeout(timeout time.Duration) Option {
+	return func(q *Queue) {
+		q.timeout = timeout
+	}
+}
+
+// WithBackoff sets the backoff for ElasticSearch write retries.
+func WithBackoff(backoff elastic.Backoff) Option {
+	return func(q *Queue) {
+		q.backoff = backoff
+	}
+}
+
+// WithErrorHandler sets the function that's called whenever an error
+// occurs in a background ElasticSearch write.
+func WithErrorHandler(errorHandler func(err error)) Option {
+	return func(q *Queue) {
+		q.errorHandler = errorHandler
+	}
+}
+
+// WithCondition sets the write conditions for the queue.
+func WithCondition(conditions ...Condition) Option {
+	return func(q *Queue) {
+		q.conditions = append(q.conditions, conditions...)
+	}
+}
+
+// WithRequester sets the requester for the queue. This is primarily for
+// testing purposes and can usually omitted unless you'd like low-level control
+// over client behavior.
+func WithRequester(requester Requester) Option {
+	return func(q *Queue) {
+		q.requester = requester
+	}
+}

--- a/option.go
+++ b/option.go
@@ -16,7 +16,9 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithBackoff sets the backoff for ElasticSearch write retries.
+// WithBackoff sets the backoff for ElasticSearch write retries. The backoff
+// is permitted to be `nil` (the default) in which case no retries will
+// be made against ElasticSearch.
 func WithBackoff(backoff elastic.Backoff) Option {
 	return func(q *Queue) {
 		q.backoff = backoff

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,3 @@
+# elasticqueue
+
+A utility library around [olivere/elastic](https://github.com/olivere/elastic) which lets you insert records to be written into a queue, which then gets bulked up when it meets a certain condition and sent to ElasticSearch.

--- a/request.go
+++ b/request.go
@@ -1,0 +1,31 @@
+package elasticqueue
+
+import (
+	"context"
+	"time"
+
+	"github.com/olivere/elastic"
+)
+
+// Requester is a simple interface around the client primarily
+// for easy mocking in tests.
+type Requester interface {
+	// Send submits the bulk request to the server.
+	Send(data []elastic.BulkableRequest) error
+}
+
+// ClientRequester is the default Requester that wraps an ElasticSearch client.
+type ClientRequester struct {
+	Client  *elastic.Client
+	Timeout time.Duration
+}
+
+var _ Requester = &ClientRequester{}
+
+// Send implements Requester.Send.
+func (c *ClientRequester) Send(data []elastic.BulkableRequest) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	_, err := c.Client.Bulk().Add(data...).Do(ctx)
+	cancel()
+	return err
+}


### PR DESCRIPTION
I've gotta run, WIP implementation, just needs some tests and final polish. An abstraction/refactoring of the queue we've been using in a couple places, allows us to define multiple and pluggable conditions for writing the queue. For example, if we want to write out after we've been idle for 10 seconds or after we have 50 items:

```go
NewQueue(client,
  WithCondition(WriteAfterLength(50)),
  WithCondition(WriteAfterIdle(time.Second*10)))
```